### PR TITLE
used regex instead of split() to support non-numeric pytorch versions

### DIFF
--- a/geffnet/layers.py
+++ b/geffnet/layers.py
@@ -1,10 +1,11 @@
+from re import findall
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 
 def versiontuple(v):
-    return tuple(map(int, (v.split("."))))[:3]
+    return tuple(findall('\d+(?=\D|$)', v)[:3])
 
 
 if versiontuple(torch.__version__) >= versiontuple('1.2.0'):


### PR DESCRIPTION
Pytorch versions such as `1.3.0a0+de394b6` produce errors in the `versiontuple` function, since python can't parse strings like `a0+de394b6` as integers. This commit instead uses `re.findall` to locate the first three sets of numeric characters followed by non-numeric characters.