### PR TITLE
Fixed EfficientNet for TorchScript

### DIFF
--- a/geffnet/config.py
+++ b/geffnet/config.py
@@ -3,7 +3,7 @@
 from typing import Any, Optional
 
 __all__ = [
-    'is_exportable', 'is_scriptable', 'is_no_jit',
+    'is_exportable', 'is_scriptable', 'is_no_jit', 'layer_config_kwargs',
     'set_exportable', 'set_scriptable', 'set_no_jit', 'set_layer_config'
 ]
 
@@ -113,3 +113,11 @@ class set_layer_config:
         global _NO_ACTIVATION_JIT
         _SCRIPTABLE, _EXPORTABLE, _NO_JIT, _NO_ACTIVATION_JIT = self.prev
         return False
+
+
+def layer_config_kwargs(kwargs):
+    """ Consume config kwargs and return contextmgr obj """
+    return set_layer_config(
+        scriptable=kwargs.pop('scriptable', None),
+        exportable=kwargs.pop('exportable', None),
+        no_jit=kwargs.pop('no_jit', None))

--- a/geffnet/conv2d_layers.py
+++ b/geffnet/conv2d_layers.py
@@ -43,7 +43,7 @@ def _get_padding(kernel_size, stride=1, dilation=1, **_):
 
 
 def _calc_same_pad(i: int, k: int, s: int, d: int):
-    return max((math.ceil(i / s) - 1) * s + (k - 1) * d + 1 - i, 0)
+    return max((-(i // -s) - 1) * s + (k - 1) * d + 1 - i, 0)
 
 
 def _same_pad_arg(input_size, kernel_size, stride, dilation):

--- a/geffnet/conv2d_layers.py
+++ b/geffnet/conv2d_layers.py
@@ -67,8 +67,7 @@ def conv2d_same(
     kh, kw = weight.size()[-2:]
     pad_h = _calc_same_pad(ih, kh, stride[0], dilation[0])
     pad_w = _calc_same_pad(iw, kw, stride[1], dilation[1])
-    if pad_h > 0 or pad_w > 0:
-        x = F.pad(x, [pad_w // 2, pad_w - pad_w // 2, pad_h // 2, pad_h - pad_h // 2])
+    x = F.pad(x, [pad_w // 2, pad_w - pad_w // 2, pad_h // 2, pad_h - pad_h // 2])
     return F.conv2d(x, weight, bias, stride, (0, 0), dilation, groups)
 
 

--- a/geffnet/efficientnet_builder.py
+++ b/geffnet/efficientnet_builder.py
@@ -8,6 +8,11 @@ from copy import deepcopy
 from .conv2d_layers import *
 from geffnet.activations import *
 
+__all__ = ['get_bn_args_tf', 'resolve_bn_args', 'resolve_se_args', 'resolve_act_layer', 'make_divisible',
+           'round_channels', 'drop_connect', 'SqueezeExcite', 'ConvBnAct', 'DepthwiseSeparableConv',
+           'InvertedResidual', 'CondConvResidual', 'EdgeResidual', 'EfficientNetBuilder', 'decode_arch_def',
+           'initialize_weight_default', 'initialize_weight_goog', 'BN_MOMENTUM_TF_DEFAULT', 'BN_EPS_TF_DEFAULT'
+]
 
 # Defaults used for Google/Tensorflow training of mobile networks /w RMSprop as per
 # papers and TF reference implementations. PT momentum equiv for TF decay is (1 - TF decay)

--- a/geffnet/gen_efficientnet.py
+++ b/geffnet/gen_efficientnet.py
@@ -29,6 +29,8 @@ Hacked together by / Copyright 2020 Ross Wightman
 import torch.nn as nn
 import torch.nn.functional as F
 
+from .config import layer_config_kwargs, is_scriptable
+from .conv2d_layers import select_conv2d
 from .helpers import load_pretrained
 from .efficientnet_builder import *
 
@@ -316,15 +318,16 @@ def _gen_mnasnet_a1(variant, channel_multiplier=1.0, pretrained=False, **kwargs)
         # stage 6, 7x7 in
         ['ir_r1_k3_s1_e6_c320'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def),
-        stem_size=32,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def),
+            stem_size=32,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -353,15 +356,16 @@ def _gen_mnasnet_b1(variant, channel_multiplier=1.0, pretrained=False, **kwargs)
         # stage 6, 7x7 in
         ['ir_r1_k3_s1_e6_c320_noskip']
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def),
-        stem_size=32,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def),
+            stem_size=32,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -383,15 +387,16 @@ def _gen_mnasnet_small(variant, channel_multiplier=1.0, pretrained=False, **kwar
         ['ir_r3_k5_s2_e6_c88_se0.25'],
         ['ir_r1_k3_s1_e6_c144']
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def),
-        stem_size=8,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def),
+            stem_size=8,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -410,17 +415,18 @@ def _gen_mobilenet_v2(
         ['ir_r3_k3_s2_e6_c160'],
         ['ir_r1_k3_s1_e6_c320'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def, depth_multiplier=depth_multiplier, fix_first_last=fix_stem_head),
-        num_features=1280 if fix_stem_head else round_channels(1280, channel_multiplier, 8, None),
-        stem_size=32,
-        fix_stem=fix_stem_head,
-        channel_multiplier=channel_multiplier,
-        norm_kwargs=resolve_bn_args(kwargs),
-        act_layer=nn.ReLU6,
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def, depth_multiplier=depth_multiplier, fix_first_last=fix_stem_head),
+            num_features=1280 if fix_stem_head else round_channels(1280, channel_multiplier, 8, None),
+            stem_size=32,
+            fix_stem=fix_stem_head,
+            channel_multiplier=channel_multiplier,
+            norm_kwargs=resolve_bn_args(kwargs),
+            act_layer=nn.ReLU6,
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -442,16 +448,17 @@ def _gen_fbnetc(variant, channel_multiplier=1.0, pretrained=False, **kwargs):
         ['ir_r4_k5_s2_e6_c184'],
         ['ir_r1_k3_s1_e6_c352'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def),
-        stem_size=16,
-        num_features=1984,  # paper suggests this, but is not 100% clear
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def),
+            stem_size=16,
+            num_features=1984,  # paper suggests this, but is not 100% clear
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -479,15 +486,16 @@ def _gen_spnasnet(variant, channel_multiplier=1.0, pretrained=False, **kwargs):
         # stage 6, 7x7 in
         ['ir_r1_k3_s1_e6_c320_noskip']
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def),
-        stem_size=32,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def),
+            stem_size=32,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -523,16 +531,17 @@ def _gen_efficientnet(variant, channel_multiplier=1.0, depth_multiplier=1.0, pre
         ['ir_r4_k5_s2_e6_c192_se0.25'],
         ['ir_r1_k3_s1_e6_c320_se0.25'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def, depth_multiplier),
-        num_features=round_channels(1280, channel_multiplier, 8, None),
-        stem_size=32,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'swish'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs,
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def, depth_multiplier),
+            num_features=round_channels(1280, channel_multiplier, 8, None),
+            stem_size=32,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'swish'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs,
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -547,16 +556,17 @@ def _gen_efficientnet_edge(variant, channel_multiplier=1.0, depth_multiplier=1.0
         ['ir_r4_k5_s1_e8_c144'],
         ['ir_r2_k5_s2_e8_c192'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def, depth_multiplier),
-        num_features=round_channels(1280, channel_multiplier, 8, None),
-        stem_size=32,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs,
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def, depth_multiplier),
+            num_features=round_channels(1280, channel_multiplier, 8, None),
+            stem_size=32,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs,
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -572,16 +582,17 @@ def _gen_efficientnet_condconv(
       ['ir_r4_k5_s2_e6_c192_se0.25_cc4'],
       ['ir_r1_k3_s1_e6_c320_se0.25_cc4'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def, depth_multiplier, experts_multiplier=experts_multiplier),
-        num_features=round_channels(1280, channel_multiplier, 8, None),
-        stem_size=32,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'swish'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs,
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def, depth_multiplier, experts_multiplier=experts_multiplier),
+            num_features=round_channels(1280, channel_multiplier, 8, None),
+            stem_size=32,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'swish'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs,
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -612,17 +623,18 @@ def _gen_efficientnet_lite(variant, channel_multiplier=1.0, depth_multiplier=1.0
         ['ir_r4_k5_s2_e6_c192'],
         ['ir_r1_k3_s1_e6_c320'],
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def, depth_multiplier, fix_first_last=True),
-        num_features=1280,
-        stem_size=32,
-        fix_stem=True,
-        channel_multiplier=channel_multiplier,
-        act_layer=nn.ReLU6,
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs,
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def, depth_multiplier, fix_first_last=True),
+            num_features=1280,
+            stem_size=32,
+            fix_stem=True,
+            channel_multiplier=channel_multiplier,
+            act_layer=nn.ReLU6,
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs,
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -647,16 +659,17 @@ def _gen_mixnet_s(variant, channel_multiplier=1.0, pretrained=False, **kwargs):
         ['ir_r1_k3.5.7.9.11_s2_e6_c200_se0.5_nsw', 'ir_r2_k3.5.7.9_p1.1_s1_e6_c200_se0.5_nsw'],  # swish
         # 7x7
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def),
-        num_features=1536,
-        stem_size=16,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def),
+            num_features=1536,
+            stem_size=16,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 
@@ -681,16 +694,17 @@ def _gen_mixnet_m(variant, channel_multiplier=1.0, depth_multiplier=1.0, pretrai
         ['ir_r1_k3.5.7.9_s2_e6_c200_se0.5_nsw', 'ir_r3_k3.5.7.9_p1.1_s1_e6_c200_se0.5_nsw'],  # swish
         # 7x7
     ]
-    model_kwargs = dict(
-        block_args=decode_arch_def(arch_def, depth_multiplier, depth_trunc='round'),
-        num_features=1536,
-        stem_size=24,
-        channel_multiplier=channel_multiplier,
-        act_layer=resolve_act_layer(kwargs, 'relu'),
-        norm_kwargs=resolve_bn_args(kwargs),
-        **kwargs
-    )
-    model = _create_model(model_kwargs, variant, pretrained)
+    with layer_config_kwargs(kwargs):
+        model_kwargs = dict(
+            block_args=decode_arch_def(arch_def, depth_multiplier, depth_trunc='round'),
+            num_features=1536,
+            stem_size=24,
+            channel_multiplier=channel_multiplier,
+            act_layer=resolve_act_layer(kwargs, 'relu'),
+            norm_kwargs=resolve_bn_args(kwargs),
+            **kwargs
+        )
+        model = _create_model(model_kwargs, variant, pretrained)
     return model
 
 

--- a/geffnet/model_factory.py
+++ b/geffnet/model_factory.py
@@ -13,15 +13,11 @@ def create_model(
         checkpoint_path='',
         **kwargs):
 
-    margs = dict(num_classes=num_classes, in_chans=in_chans, pretrained=pretrained)
+    model_kwargs = dict(num_classes=num_classes, in_chans=in_chans, pretrained=pretrained, **kwargs)
 
     if model_name in globals():
         create_fn = globals()[model_name]
-        with set_layer_config(
-                scriptable=kwargs.pop('scriptable', None),
-                exportable=kwargs.pop('exportable', None),
-                no_jit=kwargs.pop('no_jit', None)):
-            model = create_fn(**margs, **kwargs)
+        model = create_fn(**model_kwargs)
     else:
         raise RuntimeError('Unknown model (%s)' % model_name)
 


### PR DESCRIPTION

* There is an error before this fix: https://colab.research.google.com/gist/AlexeyAB/5d398fd45903b16f4db3aafeec1dbab2/effnetlite_torchscript.ipynb

* No error after fix: https://colab.research.google.com/gist/AlexeyAB/efefb642ae4ae54301690fc19c67f999/effnetlite_torchscript_fixed.ipynb

* `math.ceil(a / b)` and `math.ceil(torch.true_divide(a, b))   ` give the same result for `int` values: https://colab.research.google.com/gist/AlexeyAB/7edb6c5a324ff073628af2a80165e9d2/untitled7.ipynb

The simplest code to reproduce the error is:
```python
import torch

model = torch.hub.load(
        "rwightman/gen-efficientnet-pytorch",
        "tf_efficientnet_lite3",
        pretrained=False,
    )

rand_example = torch.rand(1, 3, 256, 256)
model = torch.jit.trace(model, rand_example)
```


>RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead.


TorchScript converts the model into a graph-mode model - so it speeds up execution,allows you to use the model on smartphones, avoids some errors when using SWA, and much more ...